### PR TITLE
Add support for group by with totals statement

### DIFF
--- a/query.go
+++ b/query.go
@@ -720,7 +720,7 @@ func (c *Client) Do(ctx context.Context, q Query) (err error) {
 				return errors.Wrap(err, "packet")
 			}
 			switch code {
-			case proto.ServerCodeData:
+			case proto.ServerCodeData, proto.ServerCodeTotals:
 				if err := c.decodeBlock(ctx, decodeOptions{
 					Handler:      onResult,
 					Result:       q.Result,


### PR DESCRIPTION
## Summary
Add support for group by with totals statement.
The totals row will be added as the last row in the response.
The row will go through the same processing as any other data.
FIXME: link to issue

## Checklist
Delete items not relevant to your PR:
- [V] Unit and integration tests covering the common scenarios were added
- [V] A human-readable description of the changes was provided to include in CHANGELOG
